### PR TITLE
Change "training-sets" to "train-sets"

### DIFF
--- a/src/training/scheduler.h
+++ b/src/training/scheduler.h
@@ -534,10 +534,10 @@ public:
   }
 
   void actAfterEpoch(TrainingState& state) override {
-    // When running self-adaptive marian in server mode the "training-sets"
+    // When running self-adaptive marian in server mode the "train-sets"
     // option isn't present because the training sentences are passed in via the
     // request body
-    if (options_->has("training-sets")) {
+    if (options_->has("train-sets")) {
       // Stop if data streaming from STDIN is stopped for a TSV input.
       auto trainingSets = options_->get<std::vector<std::string>>("train-sets");
       if (trainingSets.size() > 0) {


### PR DESCRIPTION
### Description
Fixes possible misspelling in the scheduler that causes that training never finishes if training data is provided from STDIN.

Added dependencies: none

### Checklist

- [x] I have tested the code manually
- [x] I have run regression tests
- [ ] I have read and followed CONTRIBUTING.md
- [ ] I have updated CHANGELOG.md
